### PR TITLE
Only add getters and setters for type-forwarded properties to public API

### DIFF
--- a/PublicApiAnalyzer/PublicApiAnalyzer.Test/ApiDesign/DeclarePublicAPIAnalyzerTests.cs
+++ b/PublicApiAnalyzer/PublicApiAnalyzer.Test/ApiDesign/DeclarePublicAPIAnalyzerTests.cs
@@ -465,7 +465,7 @@ C.Method() -> void
         }
 
         [Fact]
-        public async Task TypeForwardsAreProcessedAsync()
+        public async Task TypeForwardsAreProcessed1Async()
         {
             var source = @"
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.StringComparison))]
@@ -481,6 +481,34 @@ System.StringComparison.Ordinal = 4 -> System.StringComparison (forwarded, conta
 System.StringComparison.OrdinalIgnoreCase = 5 -> System.StringComparison (forwarded, contained in mscorlib)
 ";
             this.unshippedText = string.Empty;
+
+            await this.VerifyCSharpDiagnosticAsync(source, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TypeForwardsAreProcessed2Async()
+        {
+            var source = @"
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.StringComparer))]
+";
+            this.shippedText = $@"
+System.StringComparer (forwarded, contained in mscorlib)
+static System.StringComparer.InvariantCulture.get -> System.StringComparer (forwarded, contained in mscorlib)
+static System.StringComparer.InvariantCultureIgnoreCase.get -> System.StringComparer (forwarded, contained in mscorlib)
+static System.StringComparer.CurrentCulture.get -> System.StringComparer (forwarded, contained in mscorlib)
+static System.StringComparer.CurrentCultureIgnoreCase.get -> System.StringComparer (forwarded, contained in mscorlib)
+static System.StringComparer.Ordinal.get -> System.StringComparer (forwarded, contained in mscorlib)
+static System.StringComparer.OrdinalIgnoreCase.get -> System.StringComparer (forwarded, contained in mscorlib)
+static System.StringComparer.Create(System.Globalization.CultureInfo culture, bool ignoreCase) -> System.StringComparer (forwarded, contained in mscorlib)
+System.StringComparer.Compare(object x, object y) -> int (forwarded, contained in mscorlib)
+System.StringComparer.Equals(object x, object y) -> bool (forwarded, contained in mscorlib)
+System.StringComparer.GetHashCode(object obj) -> int (forwarded, contained in mscorlib)
+abstract System.StringComparer.Compare(string x, string y) -> int (forwarded, contained in mscorlib)
+abstract System.StringComparer.Equals(string x, string y) -> bool (forwarded, contained in mscorlib)
+abstract System.StringComparer.GetHashCode(string obj) -> int (forwarded, contained in mscorlib)
+System.StringComparer.StringComparer() -> void (forwarded, contained in mscorlib)
+";
+            this.unshippedText = $@"";
 
             await this.VerifyCSharpDiagnosticAsync(source, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }

--- a/PublicApiAnalyzer/PublicApiAnalyzer/ApiDesign/DeclarePublicAPIAnalyzer.Impl.cs
+++ b/PublicApiAnalyzer/PublicApiAnalyzer/ApiDesign/DeclarePublicAPIAnalyzer.Impl.cs
@@ -519,6 +519,13 @@ namespace PublicApiAnalyzer.ApiDesign
                     return false;
                 }
 
+                // We don't consider properties to be public APIs. Instead, property getters and setters
+                // (which are IMethodSymbols) are considered as public APIs.
+                if (symbol is IPropertySymbol)
+                {
+                    return false;
+                }
+
                 return this.IsPublicApiCore(symbol);
             }
 


### PR DESCRIPTION
Include changes from dotnet/roslyn-analyzers#1657