### PR TITLE
Switch from licenseUrl to license in nuspec

### DIFF
--- a/PublicApiAnalyzer/PublicApiAnalyzer.CodeFixes/PublicApiAnalyzer.Metadata.nuspec
+++ b/PublicApiAnalyzer/PublicApiAnalyzer.CodeFixes/PublicApiAnalyzer.Metadata.nuspec
@@ -6,7 +6,7 @@
     <title>$id$</title>
     <authors>Sam Harwell et. al.</authors>
     <owners>Sam Harwell</owners>
-    <licenseUrl>https://raw.githubusercontent.com/DotNetAnalyzers/PublicApiAnalyzer/$GitCommitIdShort$/LICENSE</licenseUrl>
+    <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/DotNetAnalyzers/PublicApiAnalyzer</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>An analyzer for packages with public APIs.</description>

--- a/PublicApiAnalyzer/PublicApiAnalyzer.CodeFixes/PublicApiAnalyzer.nuspec
+++ b/PublicApiAnalyzer/PublicApiAnalyzer.CodeFixes/PublicApiAnalyzer.nuspec
@@ -6,7 +6,7 @@
     <title>$id$</title>
     <authors>Sam Harwell et. al.</authors>
     <owners>Sam Harwell</owners>
-    <licenseUrl>https://raw.githubusercontent.com/DotNetAnalyzers/PublicApiAnalyzer/$version$/LICENSE</licenseUrl>
+    <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/DotNetAnalyzers/PublicApiAnalyzer</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>An analyzer for packages with public APIs.</description>


### PR DESCRIPTION
Fixes warning NU5125 on build.